### PR TITLE
Add release artifact workflow (CD)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release RobIT Artifact
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*'  # Se ejecuta solo cuando haces push de un tag como v1.0.0
 
 jobs:
   build-and-release:
@@ -21,16 +21,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest pytest-cov
 
       - name: Run tests
         run: |
           pytest --cov --cov-branch
 
-      - name: Create release package
+      - name: Create artifact
         run: |
           mkdir robit_release
-          cp -r main.py models README.md pyproject.toml robit_release/
+          cp -r main.py models README.md pyproject.toml robit_release/ || true
           zip -r RobIT-${{ github.ref_name }}.zip robit_release
 
       - name: Upload release asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release RobIT Artifact
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          pytest --cov --cov-branch
+
+      - name: Create release package
+        run: |
+          mkdir robit_release
+          cp -r main.py models README.md pyproject.toml robit_release/
+          zip -r RobIT-${{ github.ref_name }}.zip robit_release
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: RobIT-${{ github.ref_name }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
 **Add release artifact workflow (CD)**
This PR introduces a GitHub Actions workflow to enable Continuous Delivery for RobIT.

Whenever a new version tag like v1.0.0 is pushed, this workflow will:

- Run all tests with coverage

- Package the project files into a ZIP archive

- Upload the archive as an artifact in the GitHub Releases tab

